### PR TITLE
Fix c-select in case an indexing key is given.

### DIFF
--- a/content/templates/_mixins/c-select.pug
+++ b/content/templates/_mixins/c-select.pug
@@ -6,6 +6,6 @@ mixin c-select({ id, value = [A, B, C], key })
         select.c-select(id=id)
             each item in value
                 if key
-                    option= item.key
+                    option= item[key]
                 else
                     option= item

--- a/content/templates/subscription-form.pug
+++ b/content/templates/subscription-form.pug
@@ -38,7 +38,7 @@ block body
                     .o-grid-col-6
                         +c-form-group({ label: 'Code postal', id: 'tfAddressOfficalZipCode'})
                     .o-grid-col-6
-                        +c-form-group({ label: 'Pays', id: 'tfAddressOfficalCountry', type: 'select', value: contentData.countries.all })
+                        +c-form-group({ label: 'Pays', id: 'tfAddressOfficalCountry', type: 'select', value: contentData.countries.all, key: 'countryName' })
                 h3.c-h3 Adresse Courrier
                 .o-grid
                     .o-grid-col-8
@@ -51,7 +51,7 @@ block body
                         +c-form-group({ label: 'Code postal', id: 'tfAddressPostalZipCode'})
                     // @todo Fix this bug with the key not being shown correctly
                     .o-grid-col-6
-                        +c-form-group({ label: 'Pays', id: 'tfAddressPostalCountry', type: 'select', value: contentData.countries.all, key: countryName })
+                        +c-form-group({ label: 'Pays', id: 'tfAddressPostalCountry', type: 'select', value: contentData.countries.all, key: 'countryName' })
 
             // @todo enter more data
 


### PR DESCRIPTION
This fixes https://github.com/smartcoop/design/issues/21.

The mistake was that `key` in the `something.key` is a literal, not a variable. It is the same as `something['key']`, where the quotes make it clear it's a string, not a variable. Which means that if you want a variable (so its value is not hard-coded), you have to use the second form.

When you call the mixin, you don't want a variable (even if its name is `countryName`), you really want the name of the field.