### PR TITLE
Fix docker commands script

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -4,7 +4,6 @@
 # dependencies to node_modules/.
 
 if [[ $OSTYPE == "msys" ]]; then
-    MSYS_NO_PATHCONV=1 docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start
-else
-    docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start
+    export MSYS_NO_PATHCONV=1 
 fi
+docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start

--- a/develop.sh
+++ b/develop.sh
@@ -3,4 +3,8 @@
 # This runs the development server. Use ./init.sh beforehand to install the
 # dependencies to node_modules/.
 
-docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start
+if [[ $OSTYPE == "msys" ]]; then
+    MSYS_NO_PATHCONV=1 docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start
+else
+    docker run -it -w /bedrock -v $(pwd):/bedrock -p 3000:3000 node:14.15.0-buster npm start
+fi

--- a/init.sh
+++ b/init.sh
@@ -5,7 +5,6 @@
 # Use ./develop.sh to run the development server.
 
 if [[ $OSTYPE == "msys" ]]; then
-    MSYS_NO_PATHCONV=1 docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install
-else
-    docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install
+    export MSYS_NO_PATHCONV=1 
 fi
+docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install

--- a/init.sh
+++ b/init.sh
@@ -4,4 +4,8 @@
 # dependencies will be present in a local node_modules/ directory.
 # Use ./develop.sh to run the development server.
 
-docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install
+if [[ $OSTYPE == "msys" ]]; then
+    MSYS_NO_PATHCONV=1 docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install
+else
+    docker run -it -w /bedrock -v $(pwd):/bedrock node:14.15.0-buster npm install
+fi


### PR DESCRIPTION
When using Bash under Windows, there is an automatic path conversion
which has to be switched off for our docker commands to run properly.

Note that we disable the path conversion at the command level only by
adding "MSYS_NO_PATHCONV=1" right before the docker command, on the very
same line. It doesn't disable path conversion at shell (system) level.