### PR TITLE
dynamic dashboard for 1, 2 or 3 items -- without changing any parent …

### DIFF
--- a/content/scss/_p-dynamic-dashboard.scss
+++ b/content/scss/_p-dynamic-dashboard.scss
@@ -1,65 +1,55 @@
-.dynamic-dashboard{
-    display: flex;
-    flex-direction: column;
-    
-    & > div+div{
-        margin-top: 2.4rem;
-    }
-    
+.dynamic-dashboard--grid{
+    display: grid;
+    grid-gap: 2.4rem;
+    grid-auto-columns: 1fr;
     & > div{
-        flex: 1;
-        order: 2;
+        grid-row: 1;
     }
-    
-    & > .communication{
-        flex: none;
-        width: 100%;
-        order: 1;
-        margin-bottom: 2.4rem;
-        margin-top: 0;
+    @media (max-width: $g-bp4) {
+        & >  div + div + div{
+            grid-row: 2;
+            grid-column: 1 / span 2;
+        }
+    }
+    @media (max-width: $g-bp3) {
+        & > div{
+            grid-row: 1;
+            grid-column: 1 / span 2;
+        }
+        & > div + div{
+            grid-row: 2;
+        }
+        & >  div + div + div{
+            grid-row: 3;
+        }
     }
 
-    @media (min-width: $g-bp1-m) {
-        flex-direction: row;
-        & > div+div{
-            margin-left: 2.4rem;
-            margin-top: 0;
-            margin-bottom: 0;
+    @media (max-width: $g-bp2) {
+        & > div:first-child{
+            grid-row: 1;
+            grid-column: inherit;
         }
-        & > .communication{
-            width: 45%;
-            order: 3;
-            margin-bottom: 0;
-        }        
-    }
-    @media (min-width: $g-bp2) {
-        flex-direction: column;
-        & > div+div{
-            margin-left: 0;
-            margin-top: 2.4rem;
+        & > div + div{
+            grid-row: 1;
+            grid-column: inherit;
         }
-        & > .communication{
-            width: 100%;
-            order: 1;
-            margin-bottom: 2.4rem;
+        & >  div + div + div{
+            grid-row: 2;
         }
     }
-    @media (min-width: $g-bp3) {
-        flex-direction: row;
-        & > div+div{
-            margin-left: 2.4rem;
-            margin-top: 0;
-            margin-bottom: 0;
+
+    @media (max-width: $g-bp1-m) {
+        & > div:first-child{
+            grid-row: 1;
+            grid-column: 1 / span 2;
         }
-        & > .communication{
-            width: 32%;
-            order: 3;
-            margin-bottom: 0;
+        & > div + div{
+            grid-row: 2;
+            grid-column: 1 / span 2;
         }
-    }
-    @media (min-width: $g-bp4) {
-        & > .communication{
-            width: 37%;
+        & >  div + div + div{
+            grid-row: 3;
         }
     }
+   
 }

--- a/content/templates/examples/templates.pug
+++ b/content/templates/examples/templates.pug
@@ -50,6 +50,7 @@ block content
                             h4 Dashboard
                             li: a(href="/prototypes/account/dashboard.html") Dashboard without communication
                             li: a(href="/prototypes/account/dashboard-curu.html") Dashboard with curu
+                            li: a(href="/prototypes/account/dashboard-curu-communication.html") Dashboard with curu and communication
                             li: a(href="/prototypes/account/dashboard-12-01.html") Dashboard with communication from 14 december to 15 january
 
                         h2 To archive

--- a/content/templates/prototypes/account/dashboard-12-01.pug
+++ b/content/templates/prototypes/account/dashboard-12-01.pug
@@ -13,7 +13,7 @@ block content
                 .o-container.o-container--large
                     .u-spacer-bottom-l.u-spacer-top-l 
                         h1.c-h2 Bienvenue sur votre espace membre
-                    .dynamic-dashboard.u-spacer-bottom-l
+                    .dynamic-dashboard--grid.u-spacer-bottom-l
                         .c-panel
                             .c-panel__body
                                 .c-content

--- a/content/templates/prototypes/account/dashboard-curu-communication.pug
+++ b/content/templates/prototypes/account/dashboard-curu-communication.pug
@@ -26,4 +26,9 @@ block content
                                     p.u-m-t-0.u-spacer-bottom-xs Vous pouvez souscrire à une part coopérative.
                                     .c-button-toolbar.wrap
                                         +c-button({skin: 'secondary', layout: 'text-icon', icon: 'external-link'}) Souscrire une part
+                        .communication.w-30.c-card.c-card__banner(data-gradient style="--bckg-color: #228860; --title-color: #FFBC1A; --background: url('../images/banners/202212/min-banner-december-tree-2022-dsktp@1x.jpg'); --background-r: url('../images/banners/202212/min-banner-december-tree-2022-dsktp@2x.jpg'); --gradient-step-1-pos: 15%; --gradient-step-1-opacity: 0.345; --gradient-step-2-pos: 85%; --gradient-step-2-opacity: 0.20; --gradient-color: 34, 135, 95;")
+                            .c-card__banner--text
+                                .wrap
+                                    p.sub-title Smart vous<br> souhaite de
+                                    p.main-title.c-h3 joyeuses fêtes<br> de fin d'année
                     include /templates/prototypes/_includes/news

--- a/content/templates/prototypes/account/dashboard-curu.pug
+++ b/content/templates/prototypes/account/dashboard-curu.pug
@@ -13,7 +13,7 @@ block content
                 .o-container.o-container--large
                     .u-spacer-bottom-l.u-spacer-top-l 
                         h1.c-h2 Bienvenue sur votre espace membre
-                    .dynamic-dashboard.u-spacer-bottom-l
+                    .dynamic-dashboard--grid.u-spacer-bottom-l
                         .c-panel
                             .c-panel__body
                                 .c-content

--- a/content/templates/prototypes/account/dashboard.pug
+++ b/content/templates/prototypes/account/dashboard.pug
@@ -13,7 +13,7 @@ block content
                 .o-container.o-container--large
                     .u-spacer-bottom-l.u-spacer-top-l 
                         h1.c-h2 Bienvenue sur votre espace membre
-                    .dynamic-dashboard.u-spacer-bottom-l
+                    .dynamic-dashboard--grid.u-spacer-bottom-l
                         .c-panel
                             .c-panel__body
                                 .c-content


### PR DESCRIPTION
Pages à tester: Examples templates > Dashboard

Les items dans le `.dynamic-dashboard--grid` s'entrelacent parfaitement peut importe le nombre de panel qu'il comporte.

Cela va permettre de mettre et d'enlever des `panels` en fonction du projet et de la période (ex: banner de Noel) et cela sans changer de classe sur le parent.

@MEFSMART Cela facilite donc l'affichage/masquage du banner de Noel (et autres à venir).

Max 3 enfants dans `.dynamic-dashboard--grid` pour l'instant